### PR TITLE
fix missing import alias

### DIFF
--- a/import_data/import_ecoinvent/import_ecoinvent.ipynb
+++ b/import_data/import_ecoinvent/import_ecoinvent.ipynb
@@ -30,8 +30,8 @@
    "outputs": [],
    "source": [
     "# Brightway packages\n",
-    "import bw2io\n",
-    "import bw2data\n",
+    "import bw2io as bi\n",
+    "import bw2data as bd\n",
     "# Brightway type hints\n",
     "from bw2io import SingleOutputEcospold2Importer\n",
     "# import/export\n",


### PR DESCRIPTION
The import aliases in the import_ecoinvent example where missing.